### PR TITLE
Simplify travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: true
+sudo: false
 language: python
 cache: pip
 
@@ -12,23 +12,8 @@ matrix:
           env: TOXENV=py35
         - python: 3.6
           env: TOXENV=py36
-        - python: 3.7-dev
-          env: TOXENV=py37
         - python: 2.7
           env: TOXENV=qa
-    allow_failures:
-        - python: 3.7-dev
-addons:
-  apt:
-    packages:
-    - libsdl1.2-dev
-    - libsdl-image1.2-dev
-    - libsdl-mixer1.2-dev
-    - libsdl-ttf2.0-dev
-    - libportmidi-dev
-    - libfreetype6-dev
-    - libjpeg8-dev
-    - i2c-tools
 
 install: pip install -U pip tox setuptools coveralls
 script: tox -vv


### PR DESCRIPTION
* remove python 3.7 dev builder (no pygame wheels available)
* pygame wheels are used and don't require system dependencies