### PR TITLE
readthedocs: build using python3.6

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,5 +1,5 @@
 python:
-   version: 3.5
+   version: 3.6
    pip_install: true
    extra_requirements:
       - docs


### PR DESCRIPTION
to fix the error: https://readthedocs.org/projects/luma-emulator/builds/12644557/