### PR TITLE
doc: update rtd config

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,22 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: doc/conf.py
+
+# We recommend specifying your dependencies to enable reproducible builds:
+# https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+python:
+  install:
+    - requirements: docs

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,5 +1,0 @@
-python:
-   version: 3.8
-   pip_install: true
-   extra_requirements:
-      - docs


### PR DESCRIPTION
I noticed the online rtd docs haven't been build in a long time and it looks like it's related to their new config file format.

Would be nice to have https://docs.readthedocs.io/en/stable/guides/pull-requests.html setup as well but I don't have sufficient rights to setup the webhook.