### PR TITLE
luma.emulator.device.asciiart: fix compatibility with Pillow ≥ 10

### DIFF
--- a/luma/emulator/device.py
+++ b/luma/emulator/device.py
@@ -255,14 +255,14 @@ if ASCII_AVAILABLE:
             # Don't use string.printable, since we don't want any whitespace except spaces.
             charset = (string.ascii_letters + string.digits + string.punctuation + "  ")
             self._chars = list(reversed(sorted(charset, key=self._char_density)))
-            self._char_width, self._char_height = ImageFont.load_default().getsize("X")
+            self._char_width, self._char_height = ImageFont.load_default().getbbox("X")[2:]
             self._contrast = 1.0
 
         def _char_density(self, c, font=ImageFont.load_default()):
             """
             Count the number of black pixels in a rendered character.
             """
-            image = Image.new('1', font.getsize(c), color=255)
+            image = Image.new('1', font.getbbox(c)[2:], color=255)
             draw = ImageDraw.Draw(image)
             draw.text((0, 0), c, fill="white", font=font)
             return collections.Counter(image.getdata())[0]  # 0 is black
@@ -273,7 +273,7 @@ if ASCII_AVAILABLE:
             """
             # Characters aren't square, so scale the output by the aspect ratio of a charater
             height = int(height * self._char_width / float(self._char_height))
-            image = image.resize((width, height), Image.ANTIALIAS).convert("RGB")
+            image = image.resize((width, height), Image.Resampling.LANCZOS).convert("RGB")
 
             for (r, g, b) in image.getdata():
                 greyscale = int(0.299 * r + 0.587 * g + 0.114 * b)


### PR DESCRIPTION
This accounts for two interface removals in Pillow 10:

[Font size and offset methods](https://pillow.readthedocs.io/en/stable/deprecations.html#font-size-and-offset-methods). `PIL.ImageFont.ImageFont.getsize` was deprecated in [Pillow 3c0b8763abb2](https://github.com/python-pillow/Pillow/commit/3c0b8763abb26232bf304a5cdf2b046d5f7e443e) (9.2.0, 2022-07-01) and removed in [Pillow b2301d70d104](https://github.com/python-pillow/Pillow/commit/b2301d70d104f36a08ae658f569d02f7796fc8fa) (10.0.0, 2023-07-01). `PIL.ImageFont.ImageFont.getbbox`, available since [Pillow c854bf8d1c05](https://github.com/python-pillow/Pillow/commit/c854bf8d1c05022bec4309fbf6b547e494db9373) (9.2.0, 2022-07-01), can be used as the basis for a replacement. Note that since [Pillow 1e5aa21fa8ad](https://github.com/python-pillow/Pillow/commit/1e5aa21fa8addccc50ee9e76d2816aae2908d3b8) (10.1.0, 2023-10-25), `PIL.ImageFont.load_default` may load a `PIL.ImageFont.FreeTypeFont` instead of `PIL.ImageFont.ImageFont`, but `FreeTypeFont` has supported `getbbox` for even longer, since [Pillow 395aa946a9f1](https://github.com/python-pillow/Pillow/commit/395aa946a9f159f906a57f5c01a87819e2a2ed7a) (8.0.0, 2020-10-04).

[Constants](https://pillow.readthedocs.io/en/stable/deprecations.html#constants). `PIL.Image.ANTIALIAS` was deprecated in [Pillow ed8073e846dd](https://github.com/python-pillow/Pillow/commit/ed8073e846dd585227ea5462381a62414f80629b) (9.1.0, 2022-04-01) and removed in [Pillow c8ec15980b00](https://github.com/python-pillow/Pillow/commit/c8ec15980b00261d8c6a105a3dbc2a2fc634940c) (10.0.0, 2023-07-01). `PIL.Image.Resampling.LANCZOS`, available since [Pillow f8e4e9c2dd94](https://github.com/python-pillow/Pillow/commit/f8e4e9c2dd94c6f4789639dd891b8a6d5fb16e14) (9.1.0, 2022-04-01), is a direct replacement. This was previously addressed for `luma.emulator.device.asciiblock` in [dae670a8e8a9](https://github.com/rm-hull/luma.emulator/commit/dae670a8e8a939e5ffb9c395351fbff07aa2e1e4), but `luma.emulator.device.asciiart` was not updated.

Because [luma.emulator’s `setup.cfg` depends on luma.core `>= 2.4.0`](https://github.com/rm-hull/luma.emulator/blob/adc26e32cd718a732d8ae08c1720d696008161c2/setup.cfg#L35), [luma.core 2.4.0’s `setup.cfg` expresses its Pillow dependency as `>= 9.2.0`](https://github.com/rm-hull/luma.core/blob/2.4.0/setup.cfg#L31), and `PIL.ImageFont.ImageFont.getbbox` and `PIL.Image.Resampling.LANCZOS` are available in Pillow 9.2.0, there isn’t any need to make affordances for backwards compatibility with older Pillow versions.